### PR TITLE
fix: add image name_regex to example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,6 +9,7 @@ locals {
 }
 
 data "alicloud_images" "default" {
+  name_regex    = "^ubuntu_[0-9]+_[0-9]+_x64"
   most_recent   = true
   instance_type = data.alicloud_instance_types.default.instance_types[0].id
 }


### PR DESCRIPTION
Provider v1.285.0 requires at least one of `name_regex`, `image_owner_id`, or `owners` on `data.alicloud_images`.